### PR TITLE
Add 'patch' to apk add command (used by composer-patches)

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,6 +1,6 @@
 FROM php:7-alpine
 
-RUN apk --no-cache add curl git subversion openssh openssl mercurial tini bash zlib-dev
+RUN apk --no-cache add curl git subversion openssh openssl mercurial tini bash zlib-dev patch
 
 RUN echo "memory_limit=-1" > "$PHP_INI_DIR/conf.d/memory-limit.ini" \
  && echo "date.timezone=${PHP_TIMEZONE:-UTC}" > "$PHP_INI_DIR/conf.d/date_timezone.ini"


### PR DESCRIPTION
Add GNU patch to the image.

This is required by composer-patches, [as the version included with Alpine by default doesn't support some command line parameters and fails](https://github.com/cweagans/composer-patches/issues/159). 