### PR TITLE
Install to /usr/local/bin instead of /usr/bin

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -20,7 +20,7 @@ RUN curl -s -f -L -o /tmp/installer.php %COMPOSER_INSTALLER_URL% \
         echo 'Integrity check failed, installer is either corrupt or worse.' . PHP_EOL; \
         exit(1); \
     }" \
- && php /tmp/installer.php --no-ansi --install-dir=/usr/bin --filename=composer --version=${COMPOSER_VERSION} \
+ && php /tmp/installer.php --no-ansi --install-dir=/usr/local/bin --filename=composer --version=${COMPOSER_VERSION} \
  && composer --ansi --version --no-interaction \
  && rm -rf /tmp/* /tmp/.htaccess
 


### PR DESCRIPTION
/usr/bin is for executables managed by Alpine's apk package manager. See https://unix.stackexchange.com/questions/8656/usr-bin-vs-usr-local-bin-on-linux