### PR TITLE
Use PHP image based on Alpine 3.7

### DIFF
--- a/1.4/Dockerfile
+++ b/1.4/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7-alpine
+FROM php:7-alpine3.7
 
 RUN apk --no-cache add curl git subversion openssh openssl mercurial tini bash zlib-dev
 

--- a/1.5/Dockerfile
+++ b/1.5/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7-alpine
+FROM php:7-alpine3.7
 
 RUN apk --no-cache add curl git subversion openssh openssl mercurial tini bash zlib-dev
 

--- a/1.6/Dockerfile
+++ b/1.6/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7-alpine
+FROM php:7-alpine3.7
 
 RUN apk --no-cache add curl git subversion openssh openssl mercurial tini bash zlib-dev
 

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,4 +1,4 @@
-FROM php:7-alpine
+FROM php:7-alpine3.7
 
 RUN apk --no-cache add curl git subversion openssh openssl mercurial tini bash zlib-dev
 


### PR DESCRIPTION
Updating Alpine to 3.7 allows usage of fresh packages/updates.

Alpine 3.7 is a latest stable version