### PR TITLE
Add GNU make utility into image

### DIFF
--- a/1.7/Dockerfile
+++ b/1.7/Dockerfile
@@ -1,6 +1,6 @@
 FROM php:7-alpine3.8
 
-RUN apk --no-cache add git subversion openssh mercurial tini bash patch zip unzip
+RUN apk --no-cache add git subversion openssh mercurial tini bash patch make zip unzip
 
 RUN echo "memory_limit=-1" > "$PHP_INI_DIR/conf.d/memory-limit.ini" \
  && echo "date.timezone=${PHP_TIMEZONE:-UTC}" > "$PHP_INI_DIR/conf.d/date_timezone.ini"

--- a/1.8/Dockerfile
+++ b/1.8/Dockerfile
@@ -1,6 +1,6 @@
 FROM php:7-alpine3.8
 
-RUN apk --no-cache add git subversion openssh mercurial tini bash patch zip unzip
+RUN apk --no-cache add git subversion openssh mercurial tini bash patch make zip unzip
 
 RUN echo "memory_limit=-1" > "$PHP_INI_DIR/conf.d/memory-limit.ini" \
  && echo "date.timezone=${PHP_TIMEZONE:-UTC}" > "$PHP_INI_DIR/conf.d/date_timezone.ini"

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,6 +1,6 @@
 FROM php:7-alpine3.8
 
-RUN apk --no-cache add git subversion openssh mercurial tini bash patch zip unzip
+RUN apk --no-cache add git subversion openssh mercurial tini bash patch make zip unzip
 
 RUN echo "memory_limit=-1" > "$PHP_INI_DIR/conf.d/memory-limit.ini" \
  && echo "date.timezone=${PHP_TIMEZONE:-UTC}" > "$PHP_INI_DIR/conf.d/date_timezone.ini"


### PR DESCRIPTION
In our workflows we're using `Makefile`s for automating certain operations and repetitive patterns when building projects and/or using multi-lang projects. Usually, make goes in-the-box with common Debian based Docker images. However, `composer` image is built on top of Alpine, so has no `make` installed by default. This leads to weird hack in the situations described above, like running `apk add make` every time on CIs.

It would be nice to have `make` out-of-the-box in this image for smoother experience in complex builds.