### PR TITLE
Keep verification keys inside the container

### DIFF
--- a/1.7/Dockerfile
+++ b/1.7/Dockerfile
@@ -32,7 +32,7 @@ RUN curl --silent --fail --location --retry 3 --output /tmp/installer.php --url 
     }" \
  && php /tmp/installer.php --no-ansi --install-dir=/usr/bin --filename=composer --version=${COMPOSER_VERSION} \
  && composer --ansi --version --no-interaction \
- && rm -rf /tmp/* /tmp/.htaccess
+ && rm -f /tmp/installer.php
 
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 

--- a/1.8/Dockerfile
+++ b/1.8/Dockerfile
@@ -32,7 +32,7 @@ RUN curl --silent --fail --location --retry 3 --output /tmp/installer.php --url 
     }" \
  && php /tmp/installer.php --no-ansi --install-dir=/usr/bin --filename=composer --version=${COMPOSER_VERSION} \
  && composer --ansi --version --no-interaction \
- && rm -rf /tmp/* /tmp/.htaccess
+ && rm -f /tmp/installer.php
 
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -32,7 +32,7 @@ RUN curl --silent --fail --location --retry 3 --output /tmp/installer.php --url 
     }" \
  && php /tmp/installer.php --no-ansi --install-dir=/usr/bin --filename=composer --version=${COMPOSER_VERSION} \
  && composer --ansi --version --no-interaction \
- && rm -rf /tmp/* /tmp/.htaccess
+ && rm -f /tmp/installer.php
 
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 


### PR DESCRIPTION
This way the downloaded verification keys will be available inside
the container and can be used at runtime eg. in entrypoint
scripts.

... like this:
```bash
if [ ! -f "$COMPOSER_HOME/.docker-setup" ]; then
    cp --recursive /composer/* "$COMPOSER_HOME"
    composer config -g github-oauth.github.com $GUTHUB_OAUTH_TOKEN
    composer global require "hirak/prestissimo"
    composer diagnose
    echo $(date) > "$COMPOSER_HOME/.docker-setup"
fi
```