### PR TITLE
Lightweight image

### DIFF
--- a/1.8/Dockerfile
+++ b/1.8/Dockerfile
@@ -1,6 +1,6 @@
 FROM php:7-alpine
 
-RUN apk add --no-cache --virtual .composer-rundeps git subversion openssh-client mercurial tini bash patch make zip unzip coreutils \
+RUN apk add --no-cache --virtual .composer-rundeps git openssh-client tini patch make zip unzip coreutils \
  && apk add --no-cache --virtual .build-deps zlib-dev libzip-dev \
  && docker-php-ext-configure zip --with-libzip \
  && docker-php-ext-install -j$(getconf _NPROCESSORS_ONLN) zip opcache \


### PR DESCRIPTION
Composer image will run perfectly fine without this programs. Also will help to reduce the image size...
So if anyone use `COPY --from=composer:1.8 /usr/bin/composer /usr/local/bin/composer` won't have to download 100MB 

For development reason could be more helpful having composer:1.8-dev ?