### PR TITLE
Allow custom commands in composer

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,51 +1,7 @@
 #!/usr/bin/env bash
 
 isCommand() {
-  for cmd in \
-    "about" \
-    "archive" \
-    "browse" \
-    "check-platform-reqs" \
-    "clear-cache" \
-    "clearcache" \
-    "config" \
-    "create-project" \
-    "depends" \
-    "diagnose" \
-    "dump-autoload" \
-    "dumpautoload" \
-    "exec" \
-    "global" \
-    "help" \
-    "home" \
-    "info" \
-    "init" \
-    "install" \
-    "licenses" \
-    "list" \
-    "outdated" \
-    "prohibits" \
-    "remove" \
-    "require" \
-    "run-script" \
-    "search" \
-    "self-update" \
-    "selfupdate" \
-    "show" \
-    "status" \
-    "suggests" \
-    "update" \
-    "upgrade" \
-    "validate" \
-    "why" \
-    "why-not"
-  do
-    if [ -z "${cmd#"$1"}" ]; then
-      return 0
-    fi
-  done
-
-  return 1
+    return composer help $1 > dev/null
 }
 
 # check if the first argument passed in looks like a flag

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 isCommand() {
-    return composer help $1 > dev/null
+    return composer help $1 > /dev/null 2>&1 
 }
 
 # check if the first argument passed in looks like a flag


### PR DESCRIPTION
composer help $command returns correctly for built in and custom defined commands. We can use that to see if a command has been defined

Fixes #60 
