### PR TITLE
Remove bash, coreutils and patch and relay on BusyBox instead

### DIFF
--- a/1.10/Dockerfile
+++ b/1.10/Dockerfile
@@ -2,13 +2,10 @@ FROM php:7-alpine
 
 RUN set -eux; \
   apk add --no-cache --virtual .composer-rundeps \
-    bash \
-    coreutils \
     git \
     make \
     mercurial \
     openssh-client \
-    patch \
     subversion \
     tini \
     unzip \
@@ -59,6 +56,6 @@ COPY docker-entrypoint.sh /docker-entrypoint.sh
 
 WORKDIR /app
 
-ENTRYPOINT ["/bin/sh", "/docker-entrypoint.sh"]
+ENTRYPOINT ["/docker-entrypoint.sh"]
 
 CMD ["composer"]

--- a/1.10/docker-entrypoint.sh
+++ b/1.10/docker-entrypoint.sh
@@ -1,9 +1,9 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 isCommand() {
   # Retain backwards compatibility with common CI providers,
   # see: https://github.com/composer/docker/issues/107
-  if [ "$1" == "sh" ]; then
+  if [ "$1" = "sh" ]; then
     return 1
   fi
 

--- a/1.9/Dockerfile
+++ b/1.9/Dockerfile
@@ -2,13 +2,10 @@ FROM php:7-alpine
 
 RUN set -eux; \
   apk add --no-cache --virtual .composer-rundeps \
-    bash \
-    coreutils \
     git \
     make \
     mercurial \
     openssh-client \
-    patch \
     subversion \
     tini \
     unzip \
@@ -59,6 +56,6 @@ COPY docker-entrypoint.sh /docker-entrypoint.sh
 
 WORKDIR /app
 
-ENTRYPOINT ["/bin/sh", "/docker-entrypoint.sh"]
+ENTRYPOINT ["/docker-entrypoint.sh"]
 
 CMD ["composer"]

--- a/1.9/docker-entrypoint.sh
+++ b/1.9/docker-entrypoint.sh
@@ -1,9 +1,9 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 isCommand() {
   # Retain backwards compatibility with common CI providers,
   # see: https://github.com/composer/docker/issues/107
-  if [ "$1" == "sh" ]; then
+  if [ "$1" = "sh" ]; then
     return 1
   fi
 

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -2,13 +2,10 @@ FROM php:7-alpine
 
 RUN set -eux; \
   apk add --no-cache --virtual .composer-rundeps \
-    bash \
-    coreutils \
     git \
     make \
     mercurial \
     openssh-client \
-    patch \
     subversion \
     tini \
     unzip \
@@ -59,6 +56,6 @@ COPY docker-entrypoint.sh /docker-entrypoint.sh
 
 WORKDIR /app
 
-ENTRYPOINT ["/bin/sh", "/docker-entrypoint.sh"]
+ENTRYPOINT ["/docker-entrypoint.sh"]
 
 CMD ["composer"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,9 +1,9 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 isCommand() {
   # Retain backwards compatibility with common CI providers,
   # see: https://github.com/composer/docker/issues/107
-  if [ "$1" == "sh" ]; then
+  if [ "$1" = "sh" ]; then
     return 1
   fi
 


### PR DESCRIPTION
Note: all scripts need to be POSIX compatible (avoid bashisms or GNU extensions).