### PR TITLE
Pass no-interaction flag to composer help in entrypoint

### DIFF
--- a/2.2/docker-entrypoint.sh
+++ b/2.2/docker-entrypoint.sh
@@ -7,7 +7,7 @@ isCommand() {
     return 1
   fi
 
-  composer help "$1" > /dev/null 2>&1
+  composer help --no-interaction "$1" > /dev/null 2>&1
 }
 
 # check if the first argument passed in looks like a flag


### PR DESCRIPTION
Fixes https://github.com/composer/composer/issues/10393

Since the addition of the `allow-plugins` config `composer help` can now require interactive input to terminate. As the output is sent to `/dev/null` this causes running the container in certain circumstances to hang waiting for input, while sending the prompt generated to `/dev/null`.

Passing the `--no-interaction` flag will ensure the `composer help` call will neve require interaction from the user.