### PR TITLE
Add tagging and pushing of minor-specific image verions to GitHub workflow

### DIFF
--- a/.github/workflows/v1.yaml
+++ b/.github/workflows/v1.yaml
@@ -28,6 +28,7 @@ jobs:
         --no-cache \
         --target binary-with-runtime \
         --tag composer/composer:1 \
+        --tag composer/composer:1.10 \
         --tag composer/composer:$(grep -oP 'COMPOSER_VERSION 1.10.\d+' Dockerfile | grep -oP '1.10.\d+') \
         .
     # Build low-size image with binary only
@@ -38,6 +39,7 @@ jobs:
         --no-cache \
         --target standalone-binary \
         --tag composer/composer:1-bin \
+        --tag composer/composer:1.10-bin \
         --tag composer/composer:$(grep -oP 'COMPOSER_VERSION 1.10.\d+' Dockerfile | grep -oP '1.10.\d+')-bin \
         .
     - name: Login to Docker Hub
@@ -50,8 +52,10 @@ jobs:
       if: github.ref == 'refs/heads/main'
       run: |
         docker push composer/composer:1
-        docker push composer/composer:$(grep -oP 'COMPOSER_VERSION 1.10.\d+' Dockerfile | grep -oP '1.10.\d+')
         docker push composer/composer:1-bin
+        docker push composer/composer:1.10
+        docker push composer/composer:1.10-bin
+        docker push composer/composer:$(grep -oP 'COMPOSER_VERSION 1.10.\d+' Dockerfile | grep -oP '1.10.\d+')
         docker push composer/composer:$(grep -oP 'COMPOSER_VERSION 1.10.\d+' Dockerfile | grep -oP '1.10.\d+')-bin
     - name: Login to Amazon Public ECR
       if: github.ref == 'refs/heads/main'
@@ -64,10 +68,14 @@ jobs:
       if: github.ref == 'refs/heads/main'
       run: |
         docker tag composer/composer:1 $ECR_REPO:1
-        docker tag composer/composer:$(grep -oP 'COMPOSER_VERSION 1.10.\d+' Dockerfile | grep -oP '1.10.\d+') $ECR_REPO:$(grep -oP 'COMPOSER_VERSION 1.10.\d+' Dockerfile | grep -oP '1.10.\d+')
         docker tag composer/composer:1-bin $ECR_REPO:1-bin
+        docker tag composer/composer:1.10 $ECR_REPO:1.10
+        docker tag composer/composer:1.10-bin $ECR_REPO:1.10-bin
+        docker tag composer/composer:$(grep -oP 'COMPOSER_VERSION 1.10.\d+' Dockerfile | grep -oP '1.10.\d+') $ECR_REPO:$(grep -oP 'COMPOSER_VERSION 1.10.\d+' Dockerfile | grep -oP '1.10.\d+')
         docker tag composer/composer:$(grep -oP 'COMPOSER_VERSION 1.10.\d+' Dockerfile | grep -oP '1.10.\d+')-bin $ECR_REPO:$(grep -oP 'COMPOSER_VERSION 1.10.\d+' Dockerfile | grep -oP '1.10.\d+')-bin
         docker push $ECR_REPO:1
-        docker push $ECR_REPO:$(grep -oP 'COMPOSER_VERSION 1.10.\d+' Dockerfile | grep -oP '1.10.\d+')
         docker push $ECR_REPO:1-bin
+        docker push $ECR_REPO:1.10
+        docker push $ECR_REPO:1.10-bin
+        docker push $ECR_REPO:$(grep -oP 'COMPOSER_VERSION 1.10.\d+' Dockerfile | grep -oP '1.10.\d+')
         docker push $ECR_REPO:$(grep -oP 'COMPOSER_VERSION 1.10.\d+' Dockerfile | grep -oP '1.10.\d+')-bin

--- a/.github/workflows/v2.yaml
+++ b/.github/workflows/v2.yaml
@@ -28,6 +28,7 @@ jobs:
         --no-cache \
         --target binary-with-runtime \
         --tag composer/composer:lts \
+        --tag composer/composer:2.2 \
         --tag composer/composer:$(grep -oP 'COMPOSER_VERSION 2.2.\d+' Dockerfile | grep -oP '2.2.\d+') \
         .
     # Build low-size image with binary only
@@ -38,6 +39,7 @@ jobs:
         --no-cache \
         --target standalone-binary \
         --tag composer/composer:lts-bin \
+        --tag composer/composer:2.2-bin \
         --tag composer/composer:$(grep -oP 'COMPOSER_VERSION 2.2.\d+' Dockerfile | grep -oP '2.2.\d+')-bin \
         .
     - name: Login to Docker Hub
@@ -51,6 +53,8 @@ jobs:
       run: |
         docker push composer/composer:lts
         docker push composer/composer:lts-bin
+        docker push composer/composer:2.2
+        docker push composer/composer:2.2-bin
         docker push composer/composer:$(grep -oP 'COMPOSER_VERSION 2.2.\d+' Dockerfile | grep -oP '2.2.\d+')
         docker push composer/composer:$(grep -oP 'COMPOSER_VERSION 2.2.\d+' Dockerfile | grep -oP '2.2.\d+')-bin
     - name: Login to Amazon Public ECR
@@ -65,10 +69,14 @@ jobs:
       run: |
         docker tag composer/composer:lts $ECR_REPO:lts
         docker tag composer/composer:lts-bin $ECR_REPO:lts-bin
+        docker tag composer/composer:2.2 $ECR_REPO:2.2
+        docker tag composer/composer:2.2-bin $ECR_REPO:2.2-bin
         docker tag composer/composer:$(grep -oP 'COMPOSER_VERSION 2.2.\d+' Dockerfile | grep -oP '2.2.\d+') $ECR_REPO:$(grep -oP 'COMPOSER_VERSION 2.2.\d+' Dockerfile | grep -oP '2.2.\d+')
         docker tag composer/composer:$(grep -oP 'COMPOSER_VERSION 2.2.\d+' Dockerfile | grep -oP '2.2.\d+')-bin $ECR_REPO:$(grep -oP 'COMPOSER_VERSION 2.2.\d+' Dockerfile | grep -oP '2.2.\d+')-bin
         docker push $ECR_REPO:lts
         docker push $ECR_REPO:lts-bin
+        docker push $ECR_REPO:2.2
+        docker push $ECR_REPO:2.2-bin
         docker push $ECR_REPO:$(grep -oP 'COMPOSER_VERSION 2.2.\d+' Dockerfile | grep -oP '2.2.\d+')
         docker push $ECR_REPO:$(grep -oP 'COMPOSER_VERSION 2.2.\d+' Dockerfile | grep -oP '2.2.\d+')-bin
   build23:
@@ -87,6 +95,7 @@ jobs:
         --pull \
         --no-cache \
         --target binary-with-runtime \
+        --tag composer/composer:2.3 \
         --tag composer/composer:$(grep -oP 'COMPOSER_VERSION 2.3.\d+' Dockerfile | grep -oP '2.3.\d+') \
         .
     # Build low-size image with binary only
@@ -96,6 +105,7 @@ jobs:
         --pull \
         --no-cache \
         --target standalone-binary \
+        --tag composer/composer:2.3-bin \
         --tag composer/composer:$(grep -oP 'COMPOSER_VERSION 2.3.\d+' Dockerfile | grep -oP '2.3.\d+')-bin \
         .
     - name: Login to Docker Hub
@@ -107,6 +117,8 @@ jobs:
     - name: Push tag(s) to Docker Hub
       if: github.ref == 'refs/heads/main'
       run: |
+        docker push composer/composer:2.3
+        docker push composer/composer:2.3-bin
         docker push composer/composer:$(grep -oP 'COMPOSER_VERSION 2.3.\d+' Dockerfile | grep -oP '2.3.\d+')
         docker push composer/composer:$(grep -oP 'COMPOSER_VERSION 2.3.\d+' Dockerfile | grep -oP '2.3.\d+')-bin
     - name: Login to Amazon Public ECR
@@ -119,8 +131,12 @@ jobs:
     - name: Push tag(s) to Amazon Public ECR
       if: github.ref == 'refs/heads/main'
       run: |
+        docker tag composer/composer:2.3 $ECR_REPO:2.3
+        docker tag composer/composer:2.3-bin $ECR_REPO:2.3-bin
         docker tag composer/composer:$(grep -oP 'COMPOSER_VERSION 2.3.\d+' Dockerfile | grep -oP '2.3.\d+') $ECR_REPO:$(grep -oP 'COMPOSER_VERSION 2.3.\d+' Dockerfile | grep -oP '2.3.\d+')
         docker tag composer/composer:$(grep -oP 'COMPOSER_VERSION 2.3.\d+' Dockerfile | grep -oP '2.3.\d+') $ECR_REPO:$(grep -oP 'COMPOSER_VERSION 2.3.\d+' Dockerfile | grep -oP '2.3.\d+')-bin
+        docker push $ECR_REPO:2.3
+        docker push $ECR_REPO:2.3-bin
         docker push $ECR_REPO:$(grep -oP 'COMPOSER_VERSION 2.3.\d+' Dockerfile | grep -oP '2.3.\d+')
         docker push $ECR_REPO:$(grep -oP 'COMPOSER_VERSION 2.3.\d+' Dockerfile | grep -oP '2.3.\d+')-bin
   build24:
@@ -139,6 +155,7 @@ jobs:
           --pull \
           --no-cache \
           --target binary-with-runtime \
+          --tag composer/composer:2.4 \
           --tag composer/composer:$(grep -oP 'COMPOSER_VERSION 2.4.\d+' Dockerfile | grep -oP '2.4.\d+') \
           .
       # Build low-size image with binary only
@@ -148,6 +165,7 @@ jobs:
           --pull \
           --no-cache \
           --target standalone-binary \
+          --tag composer/composer:2.4-bin \
           --tag composer/composer:$(grep -oP 'COMPOSER_VERSION 2.4.\d+' Dockerfile | grep -oP '2.4.\d+')-bin \
           .
       - name: Login to Docker Hub
@@ -159,6 +177,8 @@ jobs:
       - name: Push tag(s) to Docker Hub
         if: github.ref == 'refs/heads/main'
         run: |
+          docker push composer/composer:2.4
+          docker push composer/composer:2.4-bin
           docker push composer/composer:$(grep -oP 'COMPOSER_VERSION 2.4.\d+' Dockerfile | grep -oP '2.4.\d+')
           docker push composer/composer:$(grep -oP 'COMPOSER_VERSION 2.4.\d+' Dockerfile | grep -oP '2.4.\d+')-bin
       - name: Login to Amazon Public ECR
@@ -171,8 +191,12 @@ jobs:
       - name: Push tag(s) to Amazon Public ECR
         if: github.ref == 'refs/heads/main'
         run: |
+          docker tag composer/composer:2.4 $ECR_REPO:2.4
+          docker tag composer/composer:2.4-bin $ECR_REPO:2.4-bin
           docker tag composer/composer:$(grep -oP 'COMPOSER_VERSION 2.4.\d+' Dockerfile | grep -oP '2.4.\d+') $ECR_REPO:$(grep -oP 'COMPOSER_VERSION 2.4.\d+' Dockerfile | grep -oP '2.4.\d+')
           docker tag composer/composer:$(grep -oP 'COMPOSER_VERSION 2.4.\d+' Dockerfile | grep -oP '2.4.\d+') $ECR_REPO:$(grep -oP 'COMPOSER_VERSION 2.4.\d+' Dockerfile | grep -oP '2.4.\d+')-bin
+          docker push $ECR_REPO:2.4
+          docker push $ECR_REPO:2.4-bin
           docker push $ECR_REPO:$(grep -oP 'COMPOSER_VERSION 2.4.\d+' Dockerfile | grep -oP '2.4.\d+')
           docker push $ECR_REPO:$(grep -oP 'COMPOSER_VERSION 2.4.\d+' Dockerfile | grep -oP '2.4.\d+')-bin
   build25:
@@ -193,6 +217,7 @@ jobs:
           --target binary-with-runtime \
           --tag composer/composer:latest \
           --tag composer/composer:2 \
+          --tag composer/composer:2.5 \
           --tag composer/composer:$(grep -oP 'COMPOSER_VERSION 2.5.\d+' Dockerfile | grep -oP '2.5.\d+') \
           .
       # Build low-size image with binary only
@@ -204,6 +229,7 @@ jobs:
           --target standalone-binary \
           --tag composer/composer:latest-bin \
           --tag composer/composer:2-bin \
+          --tag composer/composer:2.5-bin \
           --tag composer/composer:$(grep -oP 'COMPOSER_VERSION 2.5.\d+' Dockerfile | grep -oP '2.5.\d+')-bin \
           .
       - name: Login to Docker Hub
@@ -216,10 +242,12 @@ jobs:
         if: github.ref == 'refs/heads/main'
         run: |
           docker push composer/composer:latest
-          docker push composer/composer:2
-          docker push composer/composer:$(grep -oP 'COMPOSER_VERSION 2.5.\d+' Dockerfile | grep -oP '2.5.\d+')
           docker push composer/composer:latest-bin
+          docker push composer/composer:2
           docker push composer/composer:2-bin
+          docker push composer/composer:2.5
+          docker push composer/composer:2.5-bin
+          docker push composer/composer:$(grep -oP 'COMPOSER_VERSION 2.5.\d+' Dockerfile | grep -oP '2.5.\d+')
           docker push composer/composer:$(grep -oP 'COMPOSER_VERSION 2.5.\d+' Dockerfile | grep -oP '2.5.\d+')-bin
       - name: Login to Amazon Public ECR
         if: github.ref == 'refs/heads/main'
@@ -232,14 +260,18 @@ jobs:
         if: github.ref == 'refs/heads/main'
         run: |
           docker tag composer/composer:latest $ECR_REPO:latest
-          docker tag composer/composer:2 $ECR_REPO:2
-          docker tag composer/composer:$(grep -oP 'COMPOSER_VERSION 2.5.\d+' Dockerfile | grep -oP '2.5.\d+') $ECR_REPO:$(grep -oP 'COMPOSER_VERSION 2.5.\d+' Dockerfile | grep -oP '2.5.\d+')
           docker tag composer/composer:latest $ECR_REPO:latest-bin
+          docker tag composer/composer:2 $ECR_REPO:2
           docker tag composer/composer:2 $ECR_REPO:2-bin
+          docker tag composer/composer:2.5 $ECR_REPO:2.5
+          docker tag composer/composer:2.5-bin $ECR_REPO:2.5-bin
+          docker tag composer/composer:$(grep -oP 'COMPOSER_VERSION 2.5.\d+' Dockerfile | grep -oP '2.5.\d+') $ECR_REPO:$(grep -oP 'COMPOSER_VERSION 2.5.\d+' Dockerfile | grep -oP '2.5.\d+')
           docker tag composer/composer:$(grep -oP 'COMPOSER_VERSION 2.5.\d+' Dockerfile | grep -oP '2.5.\d+') $ECR_REPO:$(grep -oP 'COMPOSER_VERSION 2.5.\d+' Dockerfile | grep -oP '2.5.\d+')-bin
           docker push $ECR_REPO:latest
-          docker push $ECR_REPO:2
-          docker push $ECR_REPO:$(grep -oP 'COMPOSER_VERSION 2.5.\d+' Dockerfile | grep -oP '2.5.\d+')
           docker push $ECR_REPO:latest-bin
+          docker push $ECR_REPO:2
           docker push $ECR_REPO:2-bin
+          docker push $ECR_REPO:2.5
+          docker push $ECR_REPO:2.5-bin
+          docker push $ECR_REPO:$(grep -oP 'COMPOSER_VERSION 2.5.\d+' Dockerfile | grep -oP '2.5.\d+')
           docker push $ECR_REPO:$(grep -oP 'COMPOSER_VERSION 2.5.\d+' Dockerfile | grep -oP '2.5.\d+')-bin


### PR DESCRIPTION
Adds minor specific image tags (e.g. `2.5`) to the GitHub workflow. Fixes #274.

Note: while adding this, I also took the liberty to slightly rearrange the run steps to be consistent everywhere, with tags always sorted from broadest (e.g. `latest`) to most specific (e.g. `2.5.1`).