### PR TITLE
Fix: Remove 2.6 from matrix

### DIFF
--- a/.github/workflows/v2.yaml
+++ b/.github/workflows/v2.yaml
@@ -93,7 +93,6 @@ jobs:
           - "2.3"
           - "2.4"
           - "2.5"
-          - "2.6"
     steps:
     - uses: actions/checkout@v3
     # Build full image: binary with runtime


### PR DESCRIPTION
This pull request

- [x] removes `2.6` from the build matrix for previous versions

Follows #295.