### PR TITLE
Fix: Do not fail fast

### DIFF
--- a/.github/workflows/v2.yaml
+++ b/.github/workflows/v2.yaml
@@ -88,6 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     strategy:
+      fail-fast: false
       matrix:
         version:
           - "2.3"


### PR DESCRIPTION
This pull request

- [x] stops [failing fast](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast) in jobs with multiple items in the build matrix

Follows #295.