### PR TITLE
Fixed PHP version to 8.1 for older composer versions

### DIFF
--- a/2.3/Dockerfile
+++ b/2.3/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8-alpine AS binary-with-runtime
+FROM php:8.1.18-alpine3.18 AS binary-with-runtime
 
 RUN set -eux ; \
   apk add --no-cache --virtual .composer-rundeps \

--- a/2.3/Dockerfile
+++ b/2.3/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.1.18-alpine3.18 AS binary-with-runtime
+FROM php:8.1-alpine AS binary-with-runtime
 
 RUN set -eux ; \
   apk add --no-cache --virtual .composer-rundeps \

--- a/2.4/Dockerfile
+++ b/2.4/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8-alpine AS binary-with-runtime
+FROM php:8.1.18-alpine3.18 AS binary-with-runtime
 
 RUN set -eux ; \
   apk add --no-cache --virtual .composer-rundeps \

--- a/2.4/Dockerfile
+++ b/2.4/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.1.18-alpine3.18 AS binary-with-runtime
+FROM php:8.1-alpine AS binary-with-runtime
 
 RUN set -eux ; \
   apk add --no-cache --virtual .composer-rundeps \


### PR DESCRIPTION
composer:2.3 and composer:2.4 are now fixed to PHP 8.1

base container php:8-alpine is updated to latest PHP version 8.3 which is not yet supported by all packages
use fixed PHP version for older composer version for compatibility