### PR TITLE
Fix: Remove major tag from lts release

### DIFF
--- a/.github/workflows/lts.yaml
+++ b/.github/workflows/lts.yaml
@@ -56,7 +56,6 @@ jobs:
           tags: |
             type=semver,pattern={{version}},value=${{ env.COMPOSER_VERSION_MAJOR_MINOR_PATCH }}
             type=semver,pattern={{major}}.{{minor}},value=${{ env.COMPOSER_VERSION_MAJOR_MINOR_PATCH }}
-            type=semver,pattern={{major}},value=${{ env.COMPOSER_VERSION_MAJOR_MINOR_PATCH }}
             lts
           labels: |
             org.opencontainers.image.vendor=Composer
@@ -77,7 +76,6 @@ jobs:
           tags: |
             type=semver,pattern={{version}},value=${{ env.COMPOSER_VERSION_MAJOR_MINOR_PATCH }}
             type=semver,pattern={{major}}.{{minor}},value=${{ env.COMPOSER_VERSION_MAJOR_MINOR_PATCH }}
-            type=semver,pattern={{major}},value=${{ env.COMPOSER_VERSION_MAJOR_MINOR_PATCH }}
             lts
           labels: |
             org.opencontainers.image.vendor=Composer


### PR DESCRIPTION
after previous PR merged and images built, I noticed that `:2` points to lts. 
Sorry about that :facepalm: 
Issue introduced in https://github.com/composer/docker/pull/349