### PR TITLE
Update installed Alpine packages

### DIFF
--- a/latest/Dockerfile
+++ b/latest/Dockerfile
@@ -2,18 +2,18 @@ FROM php:8-alpine AS binary-with-runtime
 
 RUN set -eux ; \
   apk add --no-cache --virtual .composer-rundeps \
+    7zip \
     bash \
     coreutils \
     git \
     make \
+    mercurial \
     openssh-client \
     patch \
     subversion \
     tini \
     unzip \
-    zip \
-    $([ "$(apk --print-arch)" != "x86" ] && echo mercurial) \
-    $([ "$(apk --print-arch)" != "armhf" ] && echo p7zip)
+    zip
 
 RUN printf "# composer php cli ini settings\n\
 date.timezone=UTC\n\

--- a/legacy/Dockerfile
+++ b/legacy/Dockerfile
@@ -2,18 +2,18 @@ FROM php:8-alpine AS binary-with-runtime
 
 RUN set -eux ; \
   apk add --no-cache --virtual .composer-rundeps \
+    7zip \
     bash \
     coreutils \
     git \
     make \
+    mercurial \
     openssh-client \
     patch \
     subversion \
     tini \
     unzip \
-    zip \
-    $([ "$(apk --print-arch)" != "x86" ] && echo mercurial) \
-    $([ "$(apk --print-arch)" != "armhf" ] && echo p7zip)
+    zip
 
 RUN printf "# composer php cli ini settings\n\
 date.timezone=UTC\n\

--- a/lts/Dockerfile
+++ b/lts/Dockerfile
@@ -2,18 +2,18 @@ FROM php:8-alpine AS binary-with-runtime
 
 RUN set -eux ; \
   apk add --no-cache --virtual .composer-rundeps \
+    7zip \
     bash \
     coreutils \
     git \
     make \
+    mercurial \
     openssh-client \
     patch \
     subversion \
     tini \
     unzip \
-    zip \
-    $([ "$(apk --print-arch)" != "x86" ] && echo mercurial) \
-    $([ "$(apk --print-arch)" != "armhf" ] && echo p7zip)
+    zip
 
 RUN printf "# composer php cli ini settings\n\
 date.timezone=UTC\n\


### PR DESCRIPTION
Based on my analysis on composer installation requirements (see also https://github.com/composer/composer/discussions/12278), I spotted that the Alpine packages installed in this images could be improved in two ways:
- Replace p7zip with 7zip to follow upstream changes; see https://gitlab.alpinelinux.org/alpine/aports/-/merge_requests/46038/diffs
- Install 7zip and mercurial on all architectures; from https://pkgs.alpinelinux.org/packages?name=mercurial&branch=v3.21&repo=&arch=&origin=&flagged=&maintainer= and https://pkgs.alpinelinux.org/packages?name=7zip&branch=v3.21&repo=&arch=&origin=&flagged=&maintainer= it seems they should be available on all relevant architectures.