### PR TITLE
"ENV key=value" should be used instead of legacy "ENV key value" format

### DIFF
--- a/latest/Dockerfile
+++ b/latest/Dockerfile
@@ -20,9 +20,9 @@ date.timezone=UTC\n\
 memory_limit=-1\n\
 " > $PHP_INI_DIR/php-cli.ini
 
-ENV COMPOSER_ALLOW_SUPERUSER 1
-ENV COMPOSER_HOME /tmp
-ENV COMPOSER_VERSION 2.8.8
+ENV COMPOSER_ALLOW_SUPERUSER=1
+ENV COMPOSER_HOME=/tmp
+ENV COMPOSER_VERSION=2.8.8
 
 RUN set -eux ; \
   # install https://github.com/mlocati/docker-php-extension-installer


### PR DESCRIPTION
This error appears when building the image, see https://docs.docker.com/reference/build-checks/legacy-key-value-format/