### PR TITLE
Change 2.2 renovate to only bump patch

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -13,7 +13,7 @@
                 "composer/composer"
             ],
             "enabled": true
-        }, 
+        },
         {
             "matchFileNames": [
                 "2.2/Dockerfile"

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -13,7 +13,7 @@
                 "composer/composer"
             ],
             "enabled": true
-        },
+        }, 
         {
             "matchFileNames": [
                 "2.2/Dockerfile"
@@ -21,9 +21,10 @@
             "matchPackageNames": [
                 "composer/composer"
             ],
-            "versioning": "semver",
+            "matchUpdateTypes": [
+                "patch"
+            ],
             "commitMessageSuffix": " (2.2)",
-            "separateMinorPatch": true,
             "additionalBranchPrefix": "2.2-"
         },
         {
@@ -34,7 +35,6 @@
                 "composer/composer"
             ],
             "commitMessageSuffix": " (Latest)",
-            "separateMinorPatch": true,
             "additionalBranchPrefix": "latest-"
         }
     ],
@@ -56,7 +56,7 @@
                 "/2.2/Dockerfile$/"
             ],
             "matchStrings": [
-                "ENV COMPOSER_VERSION=[\"']?(?<currentValue>2\\.2\\.\\d+)[\"']?\\s+"
+                "ENV COMPOSER_VERSION=[\"']?(?<currentValue>\\d+\\.\\d+\\.\\d+)[\"']?\\s+"
             ],
             "datasourceTemplate": "github-releases",
             "depNameTemplate": "composer/composer"


### PR DESCRIPTION
 - Changed 2.2 to only bump patch - fixes [this issue](https://github.com/composer/docker/issues/372#issuecomment-2895747573) with it trying to bump minor
- Changed marcher  to handle all versions on 2.2 - its just for version extraction
- Removed [versioning](https://docs.renovatebot.com/configuration-options/#versioning) config - this behaviour default
- Removed [separateMinorPatch](https://docs.renovatebot.com/configuration-options/#separateminorpatch) config - not needed with branch naming and caused issues with `matchUpdateTypes` being set.

