### PR TITLE
Disable Renovate dashboard approval for all packages

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -10,6 +10,12 @@
     "separateMinorPatch": true,
     "packageRules": [
         {
+          "matchPackageNames": [
+            "*"
+          ],
+          "dependencyDashboardApproval": false
+        },
+        {
             "matchPackageNames": [
                 "composer/composer"
             ],


### PR DESCRIPTION
Saw the comment on https://github.com/composer/docker/issues/380#issuecomment-3312075828 and looked into why this is happening.

Looks like its caused by the `dependencyDashboardApproval` flag being set to true by default causing this behaviour.

Tried it on one of my repos and it did work https://github.com/inverse/cert-host-scraper

But I saw some rate limiting due to there being quite a few to create initially.