### PR TITLE
Trim dependencies

### DIFF
--- a/latest/Dockerfile
+++ b/latest/Dockerfile
@@ -1,5 +1,6 @@
 FROM php:8-alpine AS binary-with-runtime
 
+# https://github.com/composer/composer/blob/main/README.md#binary-dependencies
 RUN set -eux ; \
   apk add --no-cache --virtual .composer-rundeps \
     bash \

--- a/latest/Dockerfile
+++ b/latest/Dockerfile
@@ -25,22 +25,6 @@ ENV COMPOSER_HOME=/tmp
 ENV COMPOSER_VERSION=2.9.7
 
 RUN set -eux ; \
-  # install https://github.com/mlocati/docker-php-extension-installer
-  curl \
-    --silent \
-    --fail \
-    --location \
-    --retry 3 \
-    --output /usr/local/bin/install-php-extensions \
-    --url https://github.com/mlocati/docker-php-extension-installer/releases/download/1.2.58/install-php-extensions \
-  ; \
-  echo 182011b3dca5544a70fdeb587af44ed1760aa9a2ed37d787d0f280a99f92b008e638c37762360cd85583830a097665547849cb2293c4a0ee32c2a36ef7a349e2 /usr/local/bin/install-php-extensions | sha512sum --strict --check ; \
-  chmod +x /usr/local/bin/install-php-extensions ; \
-  # install necessary/useful extensions not included in base image
-  install-php-extensions \
-    bz2 \
-    zip \
-  ; \
   # install public keys for snapshot and tag validation, see https://composer.github.io/pubkeys.html
   curl \
     --silent \

--- a/latest/Dockerfile
+++ b/latest/Dockerfile
@@ -3,7 +3,6 @@ FROM php:8-alpine AS binary-with-runtime
 RUN set -eux ; \
   apk add --no-cache --virtual .composer-rundeps \
     bash \
-    coreutils \
     git \
     mercurial \
     openssh-client \
@@ -22,6 +21,9 @@ ENV COMPOSER_HOME=/tmp
 ENV COMPOSER_VERSION=2.9.7
 
 RUN set -eux ; \
+  apk add --no-cache --virtual .composer-builddeps \
+    coreutils \
+  ; \
   # install public keys for snapshot and tag validation, see https://composer.github.io/pubkeys.html
   curl \
     --silent \
@@ -60,6 +62,7 @@ RUN set -eux ; \
   ; \
   composer --ansi --version --no-interaction ; \
   rm -f /tmp/installer.php ; \
+  apk del .composer-builddeps ; \
   find /tmp -type d -exec chmod -v 1777 {} +
 
 COPY docker-entrypoint.sh /docker-entrypoint.sh

--- a/latest/Dockerfile
+++ b/latest/Dockerfile
@@ -2,14 +2,11 @@ FROM php:8-alpine AS binary-with-runtime
 
 RUN set -eux ; \
   apk add --no-cache --virtual .composer-rundeps \
-    7zip \
     bash \
     coreutils \
     git \
-    make \
     mercurial \
     openssh-client \
-    patch \
     subversion \
     tini \
     unzip \


### PR DESCRIPTION
This PR aims to trim dependencies to reduce image size and build time. The efforts are based on the discussion [here](https://github.com/composer/composer/discussions/12278) and subsequent changes in https://github.com/composer/composer/pull/12580. From what I've been able to deduce myself and based on the discussions, all of this can be dropped without any impact (or otherwise very minimal impact).

I've deliberately only opted to target the `latest` image and it may even be worth considering doing this only from 2.10 forwards, to even further reduce the potential scope of impact.

Note that dropping `mercurial` could also be considered to heavily reduce image size, being responsible for most of the image size (in comparison to the PHP base image), however given that I see it still being valid for some usecases, keeping it around makes some sense.